### PR TITLE
Use Swift5.10

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,15 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax.git",
-        "state": {
-          "branch": "swift-DEVELOPMENT-SNAPSHOT-2019-07-10-m",
-          "revision": "dd07c607c04a3adb61e6f973b3db88a7062c9f3c",
-          "version": null
-        }
+  "originHash" : "d22c1569a556f84df3013bad6f3a9eae59dbb9229b55e9a0b5b5b163999c1e47",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.10
 
 import PackageDescription
 
@@ -7,8 +7,7 @@ let rpath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.
 let package = Package(
     name: "SwiftTypeInference",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git",
-                 .revision("swift-DEVELOPMENT-SNAPSHOT-2019-07-10-m")),
+        .package(url: "https://github.com/apple/swift-syntax.git", exact: "510.0.1"),
     ],
     targets: [
         .target(
@@ -21,7 +20,11 @@ let package = Package(
         ),
         .target(
             name: "SwiftcAST",
-            dependencies: ["SwiftSyntax", "SwiftcBasic", "SwiftcType"]
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                "SwiftcBasic",
+                "SwiftcType"
+            ]
         ),
         .target(
             name: "SwiftcSema",
@@ -35,7 +38,7 @@ let package = Package(
             name: "SwiftCompiler",
             dependencies: ["SwiftcAST", "SwiftcSema"]
         ),
-        .target(
+        .executableTarget(
             name: "swsc",
             dependencies: ["SwiftcAST", "SwiftcSema"],
             linkerSettings: [

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,10 @@ let rpath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.
 
 let package = Package(
     name: "SwiftTypeInference",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-syntax.git", exact: "510.0.1"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
             name: "SwiftcAST",
             dependencies: [
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
                 "SwiftcBasic",
                 "SwiftcType"
             ]

--- a/Sources/SwiftcAST/ASTNode/ASTNode.swift
+++ b/Sources/SwiftcAST/ASTNode/ASTNode.swift
@@ -1,3 +1,5 @@
+import SwiftcBasic
+
 public protocol ASTNode : AnyObject, CustomStringConvertible {
     // break retain cycle
     func dispose()

--- a/Sources/SwiftcAST/ASTNode/BindOptionalExpr.swift
+++ b/Sources/SwiftcAST/ASTNode/BindOptionalExpr.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class BindOptionalExpr : Expr {

--- a/Sources/SwiftcAST/ASTNode/CallExpr.swift
+++ b/Sources/SwiftcAST/ASTNode/CallExpr.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class CallExpr : Expr {

--- a/Sources/SwiftcAST/ASTNode/ClosureExpr.swift
+++ b/Sources/SwiftcAST/ASTNode/ClosureExpr.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class ClosureExpr : Expr, DeclContext {

--- a/Sources/SwiftcAST/ASTNode/DeclRefExpr.swift
+++ b/Sources/SwiftcAST/ASTNode/DeclRefExpr.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class DeclRefExpr : Expr {

--- a/Sources/SwiftcAST/ASTNode/FunctionDecl.swift
+++ b/Sources/SwiftcAST/ASTNode/FunctionDecl.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class FunctionDecl : ValueDecl {

--- a/Sources/SwiftcAST/ASTNode/InjectIntoOptionalExpr.swift
+++ b/Sources/SwiftcAST/ASTNode/InjectIntoOptionalExpr.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class InjectIntoOptionalExpr : Expr {

--- a/Sources/SwiftcAST/ASTNode/IntegerLiteralExpr.swift
+++ b/Sources/SwiftcAST/ASTNode/IntegerLiteralExpr.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class IntegerLiteralExpr : Expr {

--- a/Sources/SwiftcAST/ASTNode/OptionalEvaluationExpr.swift
+++ b/Sources/SwiftcAST/ASTNode/OptionalEvaluationExpr.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class OptionalEvaluationExpr : Expr {

--- a/Sources/SwiftcAST/ASTNode/OverloadedDeclRefExpr.swift
+++ b/Sources/SwiftcAST/ASTNode/OverloadedDeclRefExpr.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class OverloadedDeclRefExpr : Expr {

--- a/Sources/SwiftcAST/ASTNode/SourceFile.swift
+++ b/Sources/SwiftcAST/ASTNode/SourceFile.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class SourceFile : Decl {

--- a/Sources/SwiftcAST/ASTNode/UnresolvedDeclRefExpr.swift
+++ b/Sources/SwiftcAST/ASTNode/UnresolvedDeclRefExpr.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class UnresolvedDeclRefExpr : Expr {

--- a/Sources/SwiftcAST/ASTNode/VariableDecl.swift
+++ b/Sources/SwiftcAST/ASTNode/VariableDecl.swift
@@ -1,3 +1,4 @@
+import SwiftcBasic
 import SwiftcType
 
 public final class VariableDecl : ValueDecl {

--- a/Sources/SwiftcAST/Parser.swift
+++ b/Sources/SwiftcAST/Parser.swift
@@ -129,9 +129,7 @@ public final class Parser {
             throw MessageError("param num must be 1")
         }
         let synParam = synParamList[0]
-        guard let synType = synParam.type else {
-            throw MessageError("no param type")
-        }
+        let synType = synParam.type
         
         let param: Type = try parse(type: synType)
         
@@ -206,9 +204,7 @@ public final class Parser {
             throw MessageError("param num must be 1")
         }
         let synParam = synParamList[0]
-        guard let name = synParam.firstName?.text else {
-            throw MessageError("no param name")
-        }
+        let name = synParam.firstName.text
         
         let paramType: Type? = try synParam.type.map { try parse(type: $0) }
         

--- a/Sources/SwiftcAST/Parser.swift
+++ b/Sources/SwiftcAST/Parser.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftParser
 import SwiftSyntax
 import SwiftcBasic
 import SwiftcType
@@ -31,7 +32,7 @@ public final class Parser {
     }
     
     public func parse() throws -> SourceFile {
-        let syn = try SyntaxParser.parse(source: sourceString)
+        let syn = SwiftParser.Parser.parse(source: sourceString)
 
         var data = sourceString.data(using: .utf8)!
         let size = data.count

--- a/Sources/SwiftcAST/Parser.swift
+++ b/Sources/SwiftcAST/Parser.swift
@@ -196,7 +196,7 @@ public final class Parser {
     }
     
     private func parse(_ synSig: ClosureSignatureSyntax) throws -> (VariableDecl, Type?) {
-        guard let synParamClause = synSig.parameterClause?.as(FunctionParameterClauseSyntax.self) else {
+        guard let synParamClause = synSig.parameterClause?.as(ClosureParameterClauseSyntax.self) else {
             throw MessageError("param num must be 1")
         }
         
@@ -207,7 +207,7 @@ public final class Parser {
         let synParam = synParamList[0]
         let name = synParam.firstName.text
         
-        let paramType: Type? = try parse(type: synParam.type)
+        let paramType: Type? = try synParam.type.map { try parse(type: $0) }
 
         let result: Type? = try synSig.returnClause
             .map { try parse(type: $0.type) }

--- a/Sources/SwiftcAST/Parser.swift
+++ b/Sources/SwiftcAST/Parser.swift
@@ -96,7 +96,7 @@ public final class Parser {
                 try parse(type: $0.type)
             }
             let decl = VariableDecl(source: source,
-                                    sourceRange: SourceRange(syntax: binding),
+                                    sourceRange: SourceRange(syntax: Syntax(binding)),
                                     parentContext: currentContext,
                                     name: name,
                                     initializer: initializer,
@@ -113,7 +113,7 @@ public final class Parser {
         let sig = try parse(synFunc.signature)
         
         let funcDecl = FunctionDecl(source: source,
-                                    sourceRange: SourceRange(syntax: synFunc),
+                                    sourceRange: SourceRange(syntax: Syntax(synFunc)),
                                     parentContext: currentContext,
                                     name: name,
                                     parameterType: sig.0,
@@ -178,7 +178,7 @@ public final class Parser {
         let (param, ret) = try parse(synSig)
         
         let closure = ClosureExpr(source: source,
-                                  sourceRange: SourceRange(syntax: expr),
+                                  sourceRange: SourceRange(syntax: Syntax(expr)),
                                   parentContext: currentContext,
                                   parameter: param,
                                   returnType: ret)
@@ -206,13 +206,13 @@ public final class Parser {
         let synParam = synParamList[0]
         let name = synParam.firstName.text
         
-        let paramType: Type? = try synParam.type.map { try parse(type: $0) }
-        
+        let paramType: Type? = try parse(type: synParam.type)
+
         let result: Type? = try synSig.returnClause
             .map { try parse(type: $0.type) }
 
         let param = VariableDecl(source: source,
-                                 sourceRange: SourceRange(syntax: synParam),
+                                 sourceRange: SourceRange(syntax: Syntax(synParam)),
                                  parentContext: currentContext,
                                  name: name,
                                  initializer: nil,
@@ -233,7 +233,7 @@ public final class Parser {
                 throw MessageError("param num must be 1")
             }
             let param = try parse(type: synParamList[0].type)
-            let result = try parse(type: type.returnType)
+            let result = try parse(type: type.returnClause.type)
             return FunctionType(parameter: param, result: result)
         } else {
             throw unsupportedSyntaxError(Syntax(type))

--- a/Sources/SwiftcType/FunctionType.swift
+++ b/Sources/SwiftcType/FunctionType.swift
@@ -1,3 +1,5 @@
+import SwiftcBasic
+
 public struct FunctionType : _EquatableType {
     private struct Eq : Hashable {
         public var parameter: AnyType

--- a/Sources/SwiftcType/OptionalType.swift
+++ b/Sources/SwiftcType/OptionalType.swift
@@ -1,3 +1,5 @@
+import SwiftcBasic
+
 public struct OptionalType : _EquatableType {
     public struct Eq : Hashable {
         public var wrapped: AnyType

--- a/Sources/SwiftcType/PrimitiveType.swift
+++ b/Sources/SwiftcType/PrimitiveType.swift
@@ -1,3 +1,5 @@
+import SwiftcBasic
+
 public struct PrimitiveType : _EquatableType {
     public var name: String
     

--- a/Sources/SwiftcType/TopAnyType.swift
+++ b/Sources/SwiftcType/TopAnyType.swift
@@ -1,3 +1,5 @@
+import SwiftcBasic
+
 // This is a `Swift.Any`
 // actually protocol composition...
 public struct TopAnyType : Hashable, _EquatableType {


### PR DESCRIPTION
This Pull Request will apply Swift5.10 to this hands-on.

Changes:

- Package
    - Update Swift version and swift-syntax revision. ([ref](https://x.com/omochimetaru/status/1777671086504636692))
    - Specify `platforms` explicitly due to swift-syntax. ([ref](https://github.com/apple/swift-syntax/blob/031b2e3ad22c74677ad1ff6a867fa2e9ffb2e510/Package.swift#L9-L10))
- Source codes
    - Replace deprecated properties with suggested ones.
    - Replace `switch ~ case ...` with `as(_:)` for downcast.
    - Remove some `guard ~ else ...` and `.map{ ... }` because they no longer return errors.

I confirmed this pull request passes all tests on the master branch.
However I didn't remove some warnings since I haven't finished this hands-on yet 🙈.